### PR TITLE
B8 illegals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1103,25 +1103,24 @@ impl fmt::Display for Instruction {
                     },
                     self.operands[0],
                 )
-            } else {
-                // otherwise show the bwh field
-                return write!(f, "br{}{}{}{} {}{}",
-                    if self.predicate != 0 { ".cond" } else { "" },
-                    [".sptk", ".spnt", ".dptk", ".dpnt"][self.operands[2].as_unsigned_imm() as usize],
-                    [".few", ".many"][self.operands[1].as_unsigned_imm() as usize],
-                    ["", ".clr"][self.operands[3].as_unsigned_imm() as usize],
-                    if let Operand::ImmI64(imm) = self.operands[0] {
-                        if imm >= 0 {
-                            "$+"
-                        } else {
-                            "$"
-                        }
-                    } else {
-                        ""
-                    },
-                    self.operands[0],
-                )
             }
+            // otherwise show the bwh field
+            return write!(f, "br{}{}{}{} {}{}",
+                if self.predicate == 0 { "" } else { ".cond" },
+                [".sptk", ".spnt", ".dptk", ".dpnt"][self.operands[2].as_unsigned_imm() as usize],
+                [".few", ".many"][self.operands[1].as_unsigned_imm() as usize],
+                ["", ".clr"][self.operands[3].as_unsigned_imm() as usize],
+                if let Operand::ImmI64(imm) = self.operands[0] {
+                    if imm >= 0 {
+                        "$+"
+                    } else {
+                        "$"
+                    }
+                } else {
+                    ""
+                },
+                self.operands[0],
+            )
         } else if let Opcode::Br_call = self.opcode {
             return write!(f, "br.call{}{}{} {}={}{}",
                 [".sptk", ".spnt", ".dptk", ".dpnt"][self.operands[3].as_unsigned_imm() as usize],
@@ -1718,8 +1717,7 @@ const BUNDLE_TAGS: [Option<BundleDesc>; 32] = [
 impl From<ReadError> for DecodeError {
     fn from(read_err: ReadError) -> DecodeError {
         match read_err {
-            ReadError::ExhaustedInput => DecodeError::ExhaustedInput,
-            ReadError::IOError(_) => DecodeError::ExhaustedInput,
+            ReadError::ExhaustedInput | ReadError::IOError(_) => DecodeError::ExhaustedInput,
         }
     }
 }
@@ -1942,20 +1940,12 @@ impl Decoder<IA64> for InstDecoder {
                     let mut hint = Some(word[28..30].load::<u8>());
                     // some `M` instructions don't actually have a hint, fix up after the fact.
                     match (tag, word[30..36].load::<u8>()) {
-                        (6, 0x1c) |
-                        (6, 0x1d) |
-                        (6, 0x1e) |
-                        (6, 0x1f) |
-                        (4, 0x1c) |
-                        (4, 0x1d) |
-                        (4, 0x1e) |
-                        (4, 0x1f) => {
+                        (6 | 4, 0x1c | 0x1d | 0x1e | 0x1f) => {
                             if !word[36] && word[27] {
                                 hint = None;
                             }
                         }
-                        (0, _) |
-                        (1, _) => {
+                        (0 | 1, _) => {
                             hint = None;
                         }
                         (_, _) => {}
@@ -1973,15 +1963,15 @@ impl Decoder<IA64> for InstDecoder {
             }
         }
 
-        for ((i, word), ty) in instruction_words.iter().enumerate().zip(instruction_types.iter().cloned()) {
+        for ((i, word), ty) in instruction_words.iter().enumerate().zip(instruction_types.iter().copied()) {
             if ty == InstructionType::L {
                 let instruction = decode_l_instruction(word, instruction_words[i + 1]);
                 inst.instructions[i] = instruction;
                 break;
-            } else {
-                let instruction = decode_instruction(word, ty);
-                inst.instructions[i] = instruction;
-            };
+            }
+
+            let instruction = decode_instruction(word, ty);
+            inst.instructions[i] = instruction;
         }
 
         // from here, `itanium-architecture-vol-1-2-3-4-reference-set-manual.pdf` volume 3 is
@@ -2093,7 +2083,7 @@ fn read_b_operands(encoding: OperandEncodingB, word: &BitSlice<Lsb0, u8>) -> (Op
         None => {
             panic!("should not explicitly check OperandEncodingB::None");
         }
-        B1 => {
+        B1 | B2 => {
             let imm20b = word[13..33].load::<u32>();
             let s = word[36];
             let imm = (((imm20b + ((s as u32) << 20)) as i32) << 11) >> 7;
@@ -2107,22 +2097,7 @@ fn read_b_operands(encoding: OperandEncodingB, word: &BitSlice<Lsb0, u8>) -> (Op
                 Operand::ImmU64(wh as u64),
                 Operand::ImmU64(d as u64),
             )
-        }
-        B2 => {
-            let imm20b = word[13..33].load::<u32>();
-            let s = word[36];
-            let imm = (((imm20b + ((s as u32) << 20)) as i32) << 11) >> 7;
-            let wh = word[33..35].load::<u8>();
-            let d = word[35];
-            let p = word[12];
-            four_op(
-                Option::None,
-                Operand::ImmI64(imm as i64),
-                Operand::ImmU64(p as u64),
-                Operand::ImmU64(wh as u64),
-                Operand::ImmU64(d as u64),
-            )
-        }
+        },
         B3 => {
             let imm20b = word[13..33].load::<u32>();
             let s = word[36];
@@ -2220,7 +2195,7 @@ fn read_f_operands(encoding: OperandEncodingF, word: &BitSlice<Lsb0, u8>) -> (Op
         None => {
             panic!("should not explicitly check OperandEncodingF::None");
         }
-        F1 => {
+        F1 | F2 | F3 => {
             let f1 = word[6..13].load::<u8>();
             let f2 = word[13..20].load::<u8>();
             let f3 = word[20..27].load::<u8>();
@@ -2232,33 +2207,7 @@ fn read_f_operands(encoding: OperandEncodingF, word: &BitSlice<Lsb0, u8>) -> (Op
                 Operand::FloatRegister(FloatRegister(f4)),
                 Operand::FloatRegister(FloatRegister(f2)),
             )
-        }
-        F2 => {
-            let f1 = word[6..13].load::<u8>();
-            let f2 = word[13..20].load::<u8>();
-            let f3 = word[20..27].load::<u8>();
-            let f4 = word[27..34].load::<u8>();
-            four_op(
-                Some(0),
-                Operand::FloatRegister(FloatRegister(f1)),
-                Operand::FloatRegister(FloatRegister(f3)),
-                Operand::FloatRegister(FloatRegister(f4)),
-                Operand::FloatRegister(FloatRegister(f2)),
-            )
-        }
-        F3 => {
-            let f1 = word[6..13].load::<u8>();
-            let f2 = word[13..20].load::<u8>();
-            let f3 = word[20..27].load::<u8>();
-            let f4 = word[27..34].load::<u8>();
-            four_op(
-                Some(0),
-                Operand::FloatRegister(FloatRegister(f1)),
-                Operand::FloatRegister(FloatRegister(f3)),
-                Operand::FloatRegister(FloatRegister(f4)),
-                Operand::FloatRegister(FloatRegister(f2)),
-            )
-        }
+        },
         F4 => {
             let p1 = word[6..12].load::<u8>();
             let f2 = word[13..20].load::<u8>();
@@ -2312,7 +2261,7 @@ fn read_f_operands(encoding: OperandEncodingF, word: &BitSlice<Lsb0, u8>) -> (Op
                 Operand::FloatRegister(FloatRegister(f3)),
             )
         }
-        F8 => {
+        F8 | F9 => {
             let f1 = word[6..13].load::<u8>();
             let f2 = word[13..20].load::<u8>();
             let f3 = word[20..27].load::<u8>();
@@ -2323,20 +2272,8 @@ fn read_f_operands(encoding: OperandEncodingF, word: &BitSlice<Lsb0, u8>) -> (Op
                 Operand::FloatRegister(FloatRegister(f2)),
                 Operand::FloatRegister(FloatRegister(f3)),
             )
-        }
-        F9 => {
-            let f1 = word[6..13].load::<u8>();
-            let f2 = word[13..20].load::<u8>();
-            let f3 = word[20..27].load::<u8>();
-            let _ = word[27..33].load::<u8>();
-            three_op(
-                Some(0),
-                Operand::FloatRegister(FloatRegister(f1)),
-                Operand::FloatRegister(FloatRegister(f2)),
-                Operand::FloatRegister(FloatRegister(f3)),
-            )
-        }
-        F10 => {
+        },
+        F10 | F11 => {
             let f1 = word[6..13].load::<u8>();
             let f2 = word[13..20].load::<u8>();
             let _ = word[20..27].load::<u8>();
@@ -2346,18 +2283,7 @@ fn read_f_operands(encoding: OperandEncodingF, word: &BitSlice<Lsb0, u8>) -> (Op
                 Operand::FloatRegister(FloatRegister(f1)),
                 Operand::FloatRegister(FloatRegister(f2)),
             )
-        }
-        F11 => {
-            let f1 = word[6..13].load::<u8>();
-            let f2 = word[13..20].load::<u8>();
-            let _ = word[20..27].load::<u8>();
-            let _ = word[27..33].load::<u8>();
-            two_op(
-                Some(0),
-                Operand::FloatRegister(FloatRegister(f1)),
-                Operand::FloatRegister(FloatRegister(f2)),
-            )
-        }
+        },
         F12 => {
             let _ = word[6..13].load::<u8>();
             let amask = word[13..20].load::<u8>();
@@ -2381,22 +2307,14 @@ fn read_f_operands(encoding: OperandEncodingF, word: &BitSlice<Lsb0, u8>) -> (Op
                 Operand::ImmU64(imm as u64),
             )
         }
-        F15 => {
+        F15 | F16 => {
             let imm20a = word[6..26].load::<u32>();
             let imm = ((word[36] as u32) << 20) + imm20a;
             one_op(
                 false,
                 Operand::ImmU64(imm as u64),
             )
-        }
-        F16 => {
-            let imm20a = word[6..26].load::<u32>();
-            let imm = ((word[36] as u32) << 20) + imm20a;
-            one_op(
-                false,
-                Operand::ImmU64(imm as u64),
-            )
-        }
+        },
     }
 }
 fn read_i_operands(encoding: OperandEncodingI, word: &BitSlice<Lsb0, u8>) -> (Option<u8>, [Operand; 5]) {
@@ -2418,7 +2336,7 @@ fn read_i_operands(encoding: OperandEncodingI, word: &BitSlice<Lsb0, u8>) -> (Op
                 Operand::ImmU64(count as u64),
             )
         }
-        I2 => {
+        I2 | I7 => {
             let r1 = word[6..13].load::<u8>();
             let r2 = word[13..20].load::<u8>();
             let r3 = word[20..27].load::<u8>();
@@ -2471,17 +2389,6 @@ fn read_i_operands(encoding: OperandEncodingI, word: &BitSlice<Lsb0, u8>) -> (Op
                 Operand::GPRegister(GPRegister(r1)),
                 Operand::GPRegister(GPRegister(r3)),
                 Operand::ImmU64(count as u64),
-            )
-        }
-        I7 => {
-            let r1 = word[6..13].load::<u8>();
-            let r2 = word[13..20].load::<u8>();
-            let r3 = word[20..27].load::<u8>();
-            three_op(
-                Some(0),
-                Operand::GPRegister(GPRegister(r1)),
-                Operand::GPRegister(GPRegister(r2)),
-                Operand::GPRegister(GPRegister(r3)),
             )
         }
         I8 => {
@@ -2618,22 +2525,14 @@ fn read_i_operands(encoding: OperandEncodingI, word: &BitSlice<Lsb0, u8>) -> (Op
                 Operand::GPRegister(GPRegister(r3)),
             )
         }
-        I18 => {
+        I18 | I19 => {
             let imm20 = word[6..26].load::<u32>();
             let imm = imm20 + ((word[36] as u32) << 20);
             one_op(
                 false,
                 Operand::ImmU64(imm as u64),
             )
-        }
-        I19 => {
-            let imm20 = word[6..26].load::<u32>();
-            let imm = imm20 + ((word[36] as u32) << 20);
-            one_op(
-                false,
-                Operand::ImmU64(imm as u64),
-            )
-        }
+        },
         I20 => {
             let p1 = word[6..12].load::<u8>();
             let r3 = word[20..27].load::<u8>();
@@ -2779,7 +2678,7 @@ fn read_m_operands(encoding: OperandEncodingM, word: &BitSlice<Lsb0, u8>) -> (Op
                 Operand::Memory(GPRegister(r3)),
             )
         },
-        M2 => {
+        M2 | M16 => {
             let r1 = word[6..13].load::<u8>();
             let r2 = word[13..20].load::<u8>();
             let r3 = word[20..27].load::<u8>();
@@ -2954,17 +2853,6 @@ fn read_m_operands(encoding: OperandEncodingM, word: &BitSlice<Lsb0, u8>) -> (Op
                 Operand::ImmI64(imm as i64),
             )
         }
-        M16 => {
-            let r1 = word[6..13].load::<u8>();
-            let r2 = word[13..20].load::<u8>();
-            let r3 = word[20..27].load::<u8>();
-            three_op(
-                Some(0),
-                Operand::GPRegister(GPRegister(r1)),
-                Operand::Memory(GPRegister(r3)),
-                Operand::GPRegister(GPRegister(r2)),
-            )
-        }
         M17 => {
             let r1 = word[6..13].load::<u8>();
             let i = word[13..16].load::<u8>() as i8;
@@ -3043,12 +2931,9 @@ fn read_m_operands(encoding: OperandEncodingM, word: &BitSlice<Lsb0, u8>) -> (Op
                 Operand::ImmI64(imm as i64),
             )
         }
-        M24 => {
+        M24 | M25 => {
             one_op(false, Operand::None)
-        }
-        M25 => {
-            one_op(false, Operand::None)
-        }
+        },
         M26 => {
             let r1 = word[6..13].load::<u8>();
             one_op(
@@ -3063,7 +2948,7 @@ fn read_m_operands(encoding: OperandEncodingM, word: &BitSlice<Lsb0, u8>) -> (Op
                 Operand::FloatRegister(FloatRegister(f1)),
             )
         }
-        M28 => {
+        M28 | M47 => {
             let r3 = word[20..27].load::<u8>();
             one_op(
                 false,
@@ -3170,7 +3055,7 @@ fn read_m_operands(encoding: OperandEncodingM, word: &BitSlice<Lsb0, u8>) -> (Op
                 psr,
             )
         }
-        M37 => {
+        M37 | M48 => {
             let i = word[6..26].load::<u32>() + ((word[36] as u32) << 20);
             one_op(
                 false,
@@ -3287,17 +3172,6 @@ fn read_m_operands(encoding: OperandEncodingM, word: &BitSlice<Lsb0, u8>) -> (Op
                 Operand::GPRegister(GPRegister(r3)),
             )
         }
-        M47 => {
-            let r3 = word[20..27].load::<u8>();
-            one_op(false, Operand::GPRegister(GPRegister(r3)))
-        }
-        M48 => {
-            let i = word[6..26].load::<u32>() + ((word[36] as u32) << 20);
-            one_op(
-                false,
-                Operand::ImmU64(i as u64),
-            )
-        }
     }
 }
 
@@ -3305,7 +3179,7 @@ fn read_a_operands(encoding: OperandEncodingA, word: &BitSlice<Lsb0, u8>) -> (Op
     use OperandEncodingA::*;
     match encoding {
         None => { unreachable!("none operand encoding"); }
-        A1 => {
+        A1 | A9 => {
             let r1 = word[6..13].load::<u8>();
             let r2 = word[13..20].load::<u8>();
             let r3 = word[20..27].load::<u8>();
@@ -3417,17 +3291,6 @@ fn read_a_operands(encoding: OperandEncodingA, word: &BitSlice<Lsb0, u8>) -> (Op
                 Operand::GPRegister(GPRegister(r3)),
             )
         },
-        A9 => {
-            let r1 = word[6..13].load::<u8>();
-            let r2 = word[13..20].load::<u8>();
-            let r3 = word[20..27].load::<u8>();
-            three_op(
-                Some(0),
-                Operand::GPRegister(GPRegister(r1)),
-                Operand::GPRegister(GPRegister(r2)),
-                Operand::GPRegister(GPRegister(r3)),
-            )
-        },
         A10 => {
             let r1 = word[6..13].load::<u8>();
             let r2 = word[13..20].load::<u8>();
@@ -3470,17 +3333,9 @@ fn get_l_opcode_and_encoding(tag: u8, word: &BitSlice<Lsb0, u8>) -> (Opcode, Ope
                 (Purple, None)
             }
         },
-        0x1 => { (Purple, None) },
-        0x2 => { (Purple, None) },
-        0x3 => { (Purple, None) },
-        0x4 => { (Purple, None) },
-        0x5 => { (Purple, None) },
+        0x1 | 0x2 | 0x3 | 0x4 | 0x5 | 0x7 => { (Purple, None) },
         0x6 => { (Movl, X2) },
-        0x7 => { (Purple, None) },
-        0x8 => { (Cyan, None) },
-        0x9 => { (Cyan, None) },
-        0xa => { (Cyan, None) },
-        0xb => { (Cyan, None) },
+        0x8 | 0x9 | 0xa | 0xb | 0xe | 0xf => { (Cyan, None) },
         0xc => {
             // p, wh, d, described in tables 4-51, 4-52, 4-54
             (Brl_cond_bwh_ph_dh, X3)
@@ -3489,8 +3344,6 @@ fn get_l_opcode_and_encoding(tag: u8, word: &BitSlice<Lsb0, u8>) -> (Opcode, Ope
             // p, wh, d, described in tables 4-51, 4-52, 4-54
             (Brl_call_bwh_ph_dh, X4)
         },
-        0xe => { (Cyan, None) },
-        0xf => { (Cyan, None) },
         _ => { unreachable!() },
     }
 }
@@ -3548,7 +3401,7 @@ fn get_b_opcode_and_encoding(tag: u8, word: &BitSlice<Lsb0, u8>) -> (Opcode, Ope
                 (White, None)
             }
         },
-        0x3 => { (White, None) },
+        0x3 | 0x6 => { (White, None) },
         0x4 => {
             // `Table 4-47 IP-Relative Branch Types`
             const TABLE4_47: [(Opcode, OperandEncodingB); 8] = [
@@ -3561,18 +3414,10 @@ fn get_b_opcode_and_encoding(tag: u8, word: &BitSlice<Lsb0, u8>) -> (Opcode, Ope
         0x5 => {
             (Br_call, B3)
         },
-        0x6 => { (White, None) },
         0x7 => {
             (Brp_ipwh_ih, B6)
         },
-        0x8 => { (Brown, None) },
-        0x9 => { (Brown, None) },
-        0xa => { (Brown, None) },
-        0xb => { (Brown, None) },
-        0xc => { (Brown, None) },
-        0xd => { (Brown, None) },
-        0xe => { (Brown, None) },
-        0xf => { (Brown, None) },
+        0x8 | 0x9 | 0xa | 0xb | 0xc | 0xd | 0xe | 0xf => { (Brown, None) },
         _ => { unreachable!() },
     }
 }
@@ -3659,8 +3504,7 @@ fn get_f_opcode_and_encoding(tag: u8, word: &BitSlice<Lsb0, u8>) -> (Opcode, Ope
                 TABLE4_61[word[27..33].load::<u8>() as usize]
             }
         },
-        2 => { (Purple, None) },
-        3 => { (Purple, None) },
+        0x2 | 0x3 | 0x6 | 0x7 | 0xf => { (Purple, None) },
         0x4 => {
             let index =
                 ((word[12] as u8) << 2) +
@@ -3680,8 +3524,6 @@ fn get_f_opcode_and_encoding(tag: u8, word: &BitSlice<Lsb0, u8>) -> (Opcode, Ope
                 (Fclass_m, F5)
             }
         },
-        6 => { (Purple, None) },
-        7 => { (Purple, None) },
         0x8 => {
             // from section 4.6.1.1
             if word[36] {
@@ -3744,7 +3586,6 @@ fn get_f_opcode_and_encoding(tag: u8, word: &BitSlice<Lsb0, u8>) -> (Opcode, Ope
                 (Fselect, F3)
             }
         },
-        0xf => { (Purple, None) },
         _ => { unreachable!() },
     }
 }
@@ -3799,9 +3640,7 @@ fn get_i_opcode_and_encoding(tag: u8, word: &BitSlice<Lsb0, u8>) -> (Opcode, Ope
                 }
             }
         },
-        1 => { (Purple, None) },
-        2 => { (Purple, None) },
-        3 => { (Purple, None) },
+        1 | 2 | 3 | 6 => { (Purple, None) },
         4 => { (Dep, I15) },
         5 => {
             let index = word[34..36].load::<u8>();
@@ -3866,7 +3705,6 @@ fn get_i_opcode_and_encoding(tag: u8, word: &BitSlice<Lsb0, u8>) -> (Opcode, Ope
                 }
             }
         },
-        6 => { (Purple, None) },
         7 => {
             // partial interpretation of table 4-16, `v_e == 1`
             if word[32] {
@@ -4049,8 +3887,7 @@ fn get_m_opcode_and_encoding(tag: u8, word: &BitSlice<Lsb0, u8>) -> (Opcode, Ope
                 TABLE4_44[x3 as usize]
             }
         },
-        2 => { (Purple, None) },
-        3 => { (Purple, None) },
+        2 | 3 => { (Purple, None) },
         4 => {
             // `Table 4-28 Integer Load/Store/Semaphore/Get FR 1-bit Opcode Extensions`
             const TABLE4_28: [Option<&'static [(Opcode, OperandEncodingM); 64]>; 4] = [
@@ -4130,11 +3967,7 @@ fn get_m_opcode_and_encoding(tag: u8, word: &BitSlice<Lsb0, u8>) -> (Opcode, Ope
             ];
 
             let index = ((word[36] as u8) << 1) + (word[27] as u8);
-            if let Some(op_table) = TABLE4_28[index as usize] {
-                op_table[word[30..36].load::<u8>() as usize]
-            } else {
-                (Purple, None)
-            }
+            TABLE4_28[index as usize].map_or((Purple, None), |op_table| op_table[word[30..36].load::<u8>() as usize])
         },
         5 => {
             // `Table 4-32 Integer Load/Store +Imm Opcode Extensions`
@@ -4388,11 +4221,7 @@ fn get_a_opcode_and_encoding(tag: u8, word: &BitSlice<Lsb0, u8>) -> (Opcode, Ope
                     ];
 
                     let index = ((word[36] as u8) << 1) + (word[33] as u8);
-                    if let Some(alu_table) = TABLE4_12[index as usize] {
-                        alu_table[word[27..33].load::<u8>() as usize]
-                    } else {
-                        (Purple, None)
-                    }
+                    TABLE4_12[index as usize].map_or((Purple, None), |alu_table| alu_table[word[27..33].load::<u8>() as usize])
                 },
                 2 => {
                     (Opcode::Adds, OperandEncodingA::A4)
@@ -4406,8 +4235,7 @@ fn get_a_opcode_and_encoding(tag: u8, word: &BitSlice<Lsb0, u8>) -> (Opcode, Ope
             }
         }
         9 => (Addl, A5),
-        0xa => (Purple, None),
-        0xb => (Purple, None),
+        0xa | 0xb | 0xf => (Purple, None),
         0xc => {
             // these two bits are necessary in th index regardless of other details
             let index =
@@ -4564,7 +4392,6 @@ fn get_a_opcode_and_encoding(tag: u8, word: &BitSlice<Lsb0, u8>) -> (Opcode, Ope
                 (TABLE4_10[index as usize], encoding)
             }
         }
-        0xf => (Purple, None),
         _ => {
             unreachable!("a-type major op < 8 are i-type or m-type instructions");
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1323,6 +1323,22 @@ impl yaxpeax_arch::Instruction for InstructionBundle {
             insn.predicate() == 0
         };
 
+        for insn in &self.instructions {
+            match insn.opcode {
+                // B8 family instructions cannot be predicated
+                Opcode::Cover | Opcode::Clrrb | Opcode::Clrrb_pr | Opcode::Rfi | Opcode::Bsw_0 | Opcode::Bsw_1 | Opcode::Epc => {
+                    if insn.predicate() != 0 {
+                        return false;
+                    }
+                },
+                // Undefined opcode regions
+                Opcode::Purple | Opcode::Cyan | Opcode::Brown | Opcode::White => {
+                    return false;
+                },
+                _ => {},
+            }
+        }
+
         if self.instructions[0].opcode() == Opcode::Alloc && !validate_alloc(&self.instructions[0]) {
             return false;
         }


### PR DESCRIPTION
So, this PR contains 3 things, which is technically bad but I hope you'll forgive me.

First off, @the6p4c pointed out that the B8 block of instructions are not allowed to be predicated, so that gets fixed and tested.

Then I took the opportunity to run Clippy over the codebase, and that's separated into the normal clippy lints (which are generally uncontroversial), and the pedantic lints (which might be controversial), so those can be reviewed and discussed separately.