### PR TITLE
ackowledge `ski` as ia64 decoding/emulation prior art

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ if you would like to use `yaxpeax-ia64` in a `no-std` configuration:
 
 ### exists?
 yeah i'm surprised too. the only other itanium disassemblers seem to be the one in GNU binutils and possibly one in `qemu-ia64`, but i'm not sure about the latter.
+
+additionally, there is the [`ski`](http://ski.sourceforge.net/) ia64 emulator by Hewlett-Packard, and since released as open-source. being an ia64 emulator, it includes an ia64 disassembler, and given the provenance of the project, it seems reasonable to believe it's trustworthy as well.
+
+one day, i would like to test `yaxpeax-ia64` against `ski` and `binutils`.


### PR DESCRIPTION
as @tommythorn noted in #5, the `README.md` here notes that binutils has ia64 tools, but did not mention `ski`, which looks to be a pretty comprehensive ia64 emulator.

i `ski`mmed (sorry) through the project and i'd really like to differentially test `yaxpeax-ia64` and `ski`, since it looks like `ski` is a pretty good oracle for that purpose, but i can't immediately figure out how i'd want to carve out a part of `ski` to do that. so instead it goes in the readme for one day in the future when i feel like overachieving.

one interesting note is that `ski` includes references to some instructions we know are not described by the SDM: 

```
Status movtomsrEx(INSTINFO *info)
{
    if (CPL) {
        privOpFault(0);
        return StFault;
    }
    if (SRCNAT1 || SRCNAT2) {
        regNatConsumptionFault(0);
        return StFault;
    }
    progStop("mov to msr not implemented\n");
}

Status movfrommsrEx(INSTINFO *info)
{
    if (CPL) {
        privOpFault(0);
        return StFault;
    }
    if (SRCNAT1) {
        regNatConsumptionFault(0);
        return StFault;
    }
    progStop("mov from msr not implemented\n");
}
```

and there are five more similar instructions later on:

```
/* the next 5 are implementation-dependent firmware-only instructions */

Status rfixEx(INSTINFO *info)
{
    progStop("rfi.x not implemented\n");
}

Status haltEx(INSTINFO *info)
{
    progStop("halt not implemented\n");
}

Status haltmfEx(INSTINFO *info)
{
    progStop("halt.mf not implemented\n");
}

Status ccEx(INSTINFO *info)
{
    progStop("cc not implemented\n");
}

Status probexFEx(INSTINFO *info)
{
    progStop("probe.x.fault not implemented\n");
}
```

but i can't really tell how any of these are decodable, so for now it's just clear that *something* is incomplete. unless of course these instructions are undefined by the ISA, and it's expected that system firmware might handle some kinds of `#UD`-style invalid instructions itself..